### PR TITLE
chore: added engine next as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/ai-bom
+* @snyk/engine-next @snyk/ai-bom

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   type: snyk-cli-plugin
   lifecycle: "-"
-  owner: ai-bom
+  owner: engine-next


### PR DESCRIPTION
### ❓ What does this change do?

Adds engine-next as the first codeowner