### PR TITLE
chore: added code client proxy override

### DIFF
--- a/internal/services/code/code.go
+++ b/internal/services/code/code.go
@@ -38,7 +38,6 @@ type CodeService interface {
 
 // CodeServiceImpl is an implementation of our CodeService using open telemetry.
 type CodeServiceImpl struct {
-	baseURL          string
 	pollInterval     time.Duration
 	maxNumberOfPolls int
 }
@@ -47,7 +46,6 @@ var _ CodeService = (*CodeServiceImpl)(nil) // Assert that CodeServiceImpl imple
 
 func NewCodeServiceImpl() *CodeServiceImpl {
 	return &CodeServiceImpl{
-		baseURL:          "http://localhost:9999",
 		pollInterval:     500 * time.Millisecond,
 		maxNumberOfPolls: 7200,
 	}
@@ -187,7 +185,7 @@ func uploadBundle(requestID,
 }
 
 func SnykCodeAPI(config configuration.Configuration) string {
-	if url := config.GetString(utils.ConfigurationSnykCodeAPIURL); url != "" {
+	if url := config.GetString(utils.ConfigurationSnykCodeClientProxyURL); url != "" {
 		return url
 	}
 	return strings.ReplaceAll(config.GetString(configuration.API_URL), "api", "deeproxy")

--- a/internal/services/code/code_test.go
+++ b/internal/services/code/code_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/cli-extension-ai-bom/internal/services/code"
+	"github.com/snyk/cli-extension-ai-bom/internal/utils"
 	"github.com/snyk/cli-extension-ai-bom/mocks/frameworkmock"
 	"github.com/snyk/cli-extension-ai-bom/mocks/loggermock"
 
@@ -42,6 +43,16 @@ func TestAnalyze(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, "my-aibom", resp.Sarif.Runs[0].Results[0].Message.Text)
+}
+
+func TestSnykCodeAPIProxyUrl(t *testing.T) {
+	ictx := frameworkmock.NewMockInvocationContext(t)
+	config := ictx.GetConfiguration()
+	config.Set(configuration.API_URL, "https://api.snyk.io")
+
+	assert.Equal(t, code.SnykCodeAPI(config), "https://deeproxy.snyk.io")
+	config.Set(utils.ConfigurationSnykCodeClientProxyURL, "http://localhost:1234")
+	assert.Equal(t, code.SnykCodeAPI(config), "http://localhost:1234")
 }
 
 type TestServer struct {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -1,6 +1,6 @@
 package utils
 
 const (
-	FlagExperimental            = "experimental"
-	ConfigurationSnykCodeAPIURL = "snyk_code_api_url"
+	FlagExperimental                    = "experimental"
+	ConfigurationSnykCodeClientProxyURL = "SNYK_CODE_CLIENT_PROXY_URL"
 )


### PR DESCRIPTION
### ❓ What does this change do?

Adds the ability to overwrite the code proxy url. This matches the existing environment variable used in the CLI config: https://github.com/snyk/cli/blob/ae28c666f16134f1d0876eb8aa29e0e29b0a4ed4/src/lib/config/index.ts#L93