### PR TITLE
Feat: add support for depgraphs

### DIFF
--- a/internal/commands/aibomcreate/aibomcreate.go
+++ b/internal/commands/aibomcreate/aibomcreate.go
@@ -11,14 +11,17 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
-	"github.com/snyk/cli-extension-ai-bom/internal/flags"
 	"github.com/snyk/cli-extension-ai-bom/internal/services/code"
+	"github.com/snyk/cli-extension-ai-bom/internal/utils"
+
+	"github.com/spf13/pflag"
 )
 
 var WorkflowID = workflow.NewWorkflowIdentifier("aibom")
 
 func RegisterWorkflows(e workflow.Engine) error {
-	flagset := flags.GetAiBBomFlagSet()
+	flagset := pflag.NewFlagSet("snyk-cli-extension-ai-bom", pflag.ExitOnError)
+	flagset.Bool(utils.FlagExperimental, false, "This is an experiment feature that will contain breaking changes in future revisions")
 
 	configuration := workflow.ConfigurationOptionsFromFlagset(flagset)
 	if _, err := e.Register(WorkflowID, configuration, AiBomWorkflow); err != nil {
@@ -37,13 +40,7 @@ func RunAiBomWorkflow(invocationCtx workflow.InvocationContext, codeService code
 	config := invocationCtx.GetConfiguration()
 
 	config.Set(configuration.RAW_CMD_ARGS, os.Args[1:])
-	experimental := config.GetBool(flags.FlagExperimental)
-	if url := config.GetString(flags.FlagFilesBundlestoreAPIURL); url != "" {
-		logger.Debug().Msgf("Using %s as url for files bundle store", url)
-	}
-	if url := config.GetString(flags.FlagCodeAPIURL); url != "" {
-		logger.Debug().Msgf("Using %s as url for code API", url)
-	}
+	experimental := config.GetBool(utils.FlagExperimental)
 	path := config.GetString(configuration.INPUT_DIRECTORY)
 
 	// As this is an experimental feature, we only want to continue if the experimental flag is set

--- a/internal/commands/aibomcreate/aibomcreate.go
+++ b/internal/commands/aibomcreate/aibomcreate.go
@@ -51,16 +51,18 @@ func RunAiBomWorkflow(invocationCtx workflow.InvocationContext, codeService code
 
 	logger.Debug().Msg("AI BOM workflow start")
 
-	depGraphResult, err := GetDepGraph(invocationCtx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get the depgraph: %w", err)
-	}
-	numGraphs := len(depGraphResult.DepGraphBytes)
-	logger.Debug().Msgf("Generated %d depgraph(s)\n", numGraphs)
+	if !config.GetBool(utils.FlagSkipDepGraph) {
+		depGraphResult, err := GetDepGraph(invocationCtx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get the depgraph: %w", err)
+		}
+		numGraphs := len(depGraphResult.DepGraphBytes)
+		logger.Debug().Msgf("Generated %d depgraph(s)\n", numGraphs)
 
-	_, err = writeRawMessagesToFiles(depGraphResult.DepGraphBytes, path+"/depgraphs", "deps")
-	if err != nil {
-		return nil, fmt.Errorf("writing depgraphs to files failed: %w", err)
+		_, err = writeRawMessagesToFiles(depGraphResult.DepGraphBytes, path+"/depgraphs", "deps")
+		if err != nil {
+			return nil, fmt.Errorf("writing depgraphs to files failed: %w", err)
+		}
 	}
 
 	response, resultMetaData, err := codeService.Analyze(path, invocationCtx.GetNetworkAccess().GetHttpClient, logger, config, invocationCtx.GetUserInterface())

--- a/internal/commands/aibomcreate/aibomcreate.go
+++ b/internal/commands/aibomcreate/aibomcreate.go
@@ -54,14 +54,13 @@ func RunAiBomWorkflow(invocationCtx workflow.InvocationContext, codeService code
 	depGraphResult, err := GetDepGraph(invocationCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the depgraph: %w", err)
-	} else {
-		numGraphs := len(depGraphResult.DepGraphBytes)
-		logger.Debug().Msgf("Generated %d depgraph(s)\n", numGraphs)
+	}
+	numGraphs := len(depGraphResult.DepGraphBytes)
+	logger.Debug().Msgf("Generated %d depgraph(s)\n", numGraphs)
 
-		_, err = writeRawMessagesToFiles(depGraphResult.DepGraphBytes, path+"/depgraphs", "deps")
-		if err != nil {
-			return nil, fmt.Errorf("writing depgraphs to files failed: %w", err)
-		}
+	_, err = writeRawMessagesToFiles(depGraphResult.DepGraphBytes, path+"/depgraphs", "deps")
+	if err != nil {
+		return nil, fmt.Errorf("writing depgraphs to files failed: %w", err)
 	}
 
 	response, resultMetaData, err := codeService.Analyze(path, invocationCtx.GetNetworkAccess().GetHttpClient, logger, config, invocationCtx.GetUserInterface())

--- a/internal/commands/aibomcreate/aibomcreate.go
+++ b/internal/commands/aibomcreate/aibomcreate.go
@@ -52,7 +52,8 @@ func RunAiBomWorkflow(invocationCtx workflow.InvocationContext, codeService code
 	logger.Debug().Msg("AI BOM workflow start")
 
 	if !config.GetBool(utils.FlagSkipDepGraph) {
-		depGraphResult, err := GetDepGraph(invocationCtx)
+		var depGraphResult *DepGraphResult
+		depGraphResult, err = GetDepGraph(invocationCtx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get the depgraph: %w", err)
 		}

--- a/internal/commands/aibomcreate/aibomcreate_test.go
+++ b/internal/commands/aibomcreate/aibomcreate_test.go
@@ -33,6 +33,7 @@ func TestAiBomWorkflow_HAPPY(t *testing.T) {
 	ictx := frameworkmock.NewMockInvocationContext(t)
 	ctrl := gomock.NewController(t)
 	ictx.GetConfiguration().Set(utils.FlagExperimental, true)
+	ictx.GetConfiguration().Set(utils.FlagSkipDepGraph, true)
 	mockCodeService := codemock.NewMockCodeService(ctrl)
 
 	sarif := code.Sarif{Runs: []code.SarifRun{{Results: []code.SarifResult{{Message: code.SarifMessage{Text: exampleAIBOM}}}}}}
@@ -51,6 +52,7 @@ func TestAiBomWorkflow_HAPPY(t *testing.T) {
 func TestAiBomWorkflow_ANALYSIS_FAIL(t *testing.T) {
 	ictx := frameworkmock.NewMockInvocationContext(t)
 	ictx.GetConfiguration().Set(utils.FlagExperimental, true)
+	ictx.GetConfiguration().Set(utils.FlagSkipDepGraph, true)
 	ctrl := gomock.NewController(t)
 	mockCodeService := codemock.NewMockCodeService(ctrl)
 

--- a/internal/commands/aibomcreate/depgraph.go
+++ b/internal/commands/aibomcreate/depgraph.go
@@ -1,0 +1,42 @@
+package aibomcreate
+
+import (
+	"encoding/json"
+
+	"github.com/snyk/go-application-framework/pkg/workflow"
+)
+
+var DepGraphWorkflowID = workflow.NewWorkflowIdentifier("depgraph")
+
+type DepGraphResult struct {
+	DepGraphBytes []json.RawMessage
+}
+
+func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
+	engine := ictx.GetEngine()
+	config := ictx.GetConfiguration()
+	logger := ictx.GetLogger()
+
+	logger.Println("Invoking depgraph workflow")
+
+	depGraphConfig := config.Clone()
+	depGraphs, err := engine.InvokeWithConfig(DepGraphWorkflowID, depGraphConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	numGraphs := len(depGraphs)
+	logger.Printf("Generated documents for %d depgraph(s)\n", numGraphs)
+	depGraphsBytes := make([]json.RawMessage, numGraphs)
+	for i, depGraph := range depGraphs {
+		depGraphBytes, err := getPayloadBytes(depGraph)
+		if err != nil {
+			return nil, err
+		}
+		depGraphsBytes[i] = depGraphBytes
+	}
+
+	return &DepGraphResult{
+		DepGraphBytes: depGraphsBytes,
+	}, nil
+}

--- a/internal/commands/aibomcreate/depgraph.go
+++ b/internal/commands/aibomcreate/depgraph.go
@@ -2,6 +2,7 @@ package aibomcreate
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )

--- a/internal/commands/aibomcreate/depgraph.go
+++ b/internal/commands/aibomcreate/depgraph.go
@@ -22,7 +22,7 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 	depGraphConfig := config.Clone()
 	depGraphs, err := engine.InvokeWithConfig(DepGraphWorkflowID, depGraphConfig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error invoking depgraphs workflow: %w", err)
 	}
 
 	numGraphs := len(depGraphs)

--- a/internal/commands/aibomcreate/util.go
+++ b/internal/commands/aibomcreate/util.go
@@ -1,0 +1,16 @@
+package aibomcreate
+
+import (
+	"fmt"
+
+	"github.com/snyk/go-application-framework/pkg/workflow"
+)
+
+func getPayloadBytes(data workflow.Data) ([]byte, error) {
+	payload := data.GetPayload()
+	bytes, ok := payload.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("invalid payload type (want []byte, got %T)", payload)
+	}
+	return bytes, nil
+}

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -1,6 +1,12 @@
 package utils
 
 const (
+<<<<<<< HEAD
 	FlagExperimental                    = "experimental"
 	ConfigurationSnykCodeClientProxyURL = "SNYK_CODE_CLIENT_PROXY_URL"
+=======
+	FlagExperimental            = "experimental"
+	FlagSkipDepGraph = "skip-dep-graph"
+	ConfigurationSnykCodeAPIURL = "snyk_code_api_url"
+>>>>>>> e6a7076 (chore: gate dep graphs behind config flag)
 )

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -6,7 +6,7 @@ const (
 	ConfigurationSnykCodeClientProxyURL = "SNYK_CODE_CLIENT_PROXY_URL"
 =======
 	FlagExperimental            = "experimental"
-	FlagSkipDepGraph = "skip-dep-graph"
+	FlagSkipDepGraph 			= "skip-dep-graph"
 	ConfigurationSnykCodeAPIURL = "snyk_code_api_url"
 >>>>>>> e6a7076 (chore: gate dep graphs behind config flag)
 )

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -1,12 +1,7 @@
 package utils
 
 const (
-<<<<<<< HEAD
 	FlagExperimental                    = "experimental"
+	FlagSkipDepGraph                    = "skip-dep-graph"
 	ConfigurationSnykCodeClientProxyURL = "SNYK_CODE_CLIENT_PROXY_URL"
-=======
-	FlagExperimental            = "experimental"
-	FlagSkipDepGraph            = "skip-dep-graph"
-	ConfigurationSnykCodeAPIURL = "snyk_code_api_url"
->>>>>>> e6a7076 (chore: gate dep graphs behind config flag)
 )

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -6,7 +6,7 @@ const (
 	ConfigurationSnykCodeClientProxyURL = "SNYK_CODE_CLIENT_PROXY_URL"
 =======
 	FlagExperimental            = "experimental"
-	FlagSkipDepGraph 			= "skip-dep-graph"
+	FlagSkipDepGraph            = "skip-dep-graph"
 	ConfigurationSnykCodeAPIURL = "snyk_code_api_url"
 >>>>>>> e6a7076 (chore: gate dep graphs behind config flag)
 )


### PR DESCRIPTION
Add support for getting DepGraphs in current ai-bom cli extension.
For this PR, the resulting depgraphs are written to a file.

Closed, as changes have been moved to [this PR](https://github.com/snyk/cli-extension-ai-bom/pull/19).