### PR TITLE
chore: update error catalog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/rs/zerolog v1.33.0
 	github.com/snyk/code-client-go v1.19.0
-	github.com/snyk/error-catalog-golang-public v0.0.0-20250520083045-87fdeaf670ba
+	github.com/snyk/error-catalog-golang-public v0.0.0-20250520155934-078275889e2c
 	github.com/snyk/go-application-framework v0.0.0-20250325133828-3ffd1aa4f76f
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnB
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/snyk/code-client-go v1.19.0 h1:4r1cezH93FqLOkhWwUTsPCu/93z/YD8TicefV/Njqd8=
 github.com/snyk/code-client-go v1.19.0/go.mod h1:WH6lNkJc785hfXmwhixxWHix3O6z+1zwz40oK8vl/zg=
-github.com/snyk/error-catalog-golang-public v0.0.0-20250520083045-87fdeaf670ba h1:aCeGjZwerdqSiz0SGsFt33CMU3IuAiEuHJQbrurR7q8=
-github.com/snyk/error-catalog-golang-public v0.0.0-20250520083045-87fdeaf670ba/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
+github.com/snyk/error-catalog-golang-public v0.0.0-20250520155934-078275889e2c h1:rXUCGepwK38Xn00MKwfJRd5ecQ7ylvkudoMFBycIJUk=
+github.com/snyk/error-catalog-golang-public v0.0.0-20250520155934-078275889e2c/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-application-framework v0.0.0-20250325133828-3ffd1aa4f76f h1:1EPrRhLQ5Bo0SmIqoAU38Et1Bv2klCbyfgLmVJfUyvM=
 github.com/snyk/go-application-framework v0.0.0-20250325133828-3ffd1aa4f76f/go.mod h1:A7oFVjMjNukzsMeiIWXEXjCrAf2ARvoK4aQOm9e3E/Y=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=


### PR DESCRIPTION
### ❓ What does this change do?

The errors were showing up with unusual [white spacing](https://snyk.slack.com/archives/C073HFTPLSF/p1747753590223349?thread_ts=1747657236.367369&cid=C073HFTPLSF). Those were fixed, so this introduces the fix by bumping the version.