### PR TITLE
chore: tidied up CLI errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -62,7 +62,6 @@ linters:
         linters:
           - errcheck
 
-
 linters-settings:
   errcheck:
     check-blank: true
@@ -114,6 +113,7 @@ linters-settings:
       - name: dot-imports
       - name: error-return
       - name: error-strings
+        disabled: true # Requires all error messages to start with lower case characters. This conflicts with Snyk's public error message standards.
       - name: error-naming
       - name: exported
         arguments:
@@ -138,5 +138,5 @@ linters-settings:
   staticcheck:
     checks: ["all"]
   stylecheck:
-    checks: ["all"]
+    checks: ["all", "-ST1005"] # ST1005 requires all error messages to start with lower case characters. This conflicts with Snyk's public error message standards.
     http-status-code-whitelist: []

--- a/internal/commands/aibomcreate/aibomcreate.go
+++ b/internal/commands/aibomcreate/aibomcreate.go
@@ -59,7 +59,7 @@ func RunAiBomWorkflow(invocationCtx workflow.InvocationContext, codeService code
 	}
 	logger.Debug().Msgf("Result metadata: %+v", resultMetaData)
 
-	aiBomDoc, err := extractSbomFromResult(response, logger)
+	aiBomDoc, err := extractAiBomFromResult(response, logger)
 	if err != nil {
 		return nil, errors.NewInternalError(err.Error()).SnykError
 	}
@@ -68,14 +68,14 @@ func RunAiBomWorkflow(invocationCtx workflow.InvocationContext, codeService code
 	return aiBomDoc, nil
 }
 
-func extractSbomFromResult(response *code.AnalysisResponse, logger *zerolog.Logger) (output []workflow.Data, err error) {
+func extractAiBomFromResult(response *code.AnalysisResponse, logger *zerolog.Logger) (output []workflow.Data, err error) {
 	if len(response.Sarif.Runs) != 1 {
 		logger.Debug().Msgf("failed to extract AI-BOM from result, %d runs in result, expected 1", len(response.Sarif.Runs))
-		return nil, goErrors.New("failed to extract AI-BOM from result")
+		return nil, goErrors.New("Failed to extract AI-BOM from result.")
 	}
 	if len(response.Sarif.Runs[0].Results) != 1 {
-		logger.Debug().Msgf("Failed to extract SBOM from result, %d results in Runs[0], expected 1", len(response.Sarif.Runs[0].Results))
-		return nil, goErrors.New("failed to extract AI-BOM from result")
+		logger.Debug().Msgf("Failed to extract AI-BOM from result, %d results in Runs[0], expected 1", len(response.Sarif.Runs[0].Results))
+		return nil, goErrors.New("Failed to extract AI-BOM from result.")
 	}
 	return []workflow.Data{newWorkflowData("application/json", []byte(response.Sarif.Runs[0].Results[0].Message.Text))}, nil
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -24,10 +24,10 @@ func NewInternalError(msg string) *AiBomError {
 	return &AiBomError{SnykError: aibom_errors.NewInternalError(msg)}
 }
 
-func NewNoSupportedFilesError(msg string) *AiBomError {
-	return &AiBomError{SnykError: aibom_errors.NewNoSupportedFilesError(msg)}
+func NewNoSupportedFilesError() *AiBomError {
+	return &AiBomError{SnykError: aibom_errors.NewNoSupportedFilesError("")}
 }
 
 func NewCommandIsExperimentalError() *AiBomError {
-	return &AiBomError{SnykError: cli_errors.NewCommandIsExperimentalError("snyk aibom is experimental and likely to change")}
+	return &AiBomError{SnykError: cli_errors.NewCommandIsExperimentalError("Snyk aibom is experimental and likely to change.")}
 }

--- a/internal/services/code/code_test.go
+++ b/internal/services/code/code_test.go
@@ -72,7 +72,7 @@ func TestAnalyze_FiltersFails(t *testing.T) {
 	resp, _, err := codeService.Analyze(getDir(), clientFactory, logger, ictx.GetConfiguration(), ictx.GetUserInterface())
 
 	assert.Equal(t, "SNYK-AI-BOM-0001", err.SnykError.ErrorCode)
-	assertSnykError(t, "failed to upload bundle: error creating bundle...: Get \"/filters\": filters error", err.SnykError)
+	assertSnykError(t, "Failed to upload bundle: error creating bundle...: Get \"/filters\": filters error.", err.SnykError)
 	assert.Nil(t, resp)
 }
 
@@ -99,7 +99,7 @@ func TestAnalyze_BundleHTTPError(t *testing.T) {
 	resp, _, err := codeService.Analyze(getDir(), clientFactory, logger, ictx.GetConfiguration(), ictx.GetUserInterface())
 
 	assert.Equal(t, "SNYK-AI-BOM-0001", err.SnykError.ErrorCode)
-	assertSnykError(t, "failed to upload bundle: error creating bundle...: Post \"/bundle\": bundle error", err.SnykError)
+	assertSnykError(t, "Failed to upload bundle: error creating bundle...: Post \"/bundle\": bundle error.", err.SnykError)
 	assert.Nil(t, resp)
 }
 
@@ -126,11 +126,37 @@ func TestAnalyze_AuthenticationError(t *testing.T) {
 	resp, _, err := codeService.Analyze(getDir(), clientFactory, logger, ictx.GetConfiguration(), ictx.GetUserInterface())
 
 	assert.Equal(t, "SNYK-0005", err.SnykError.ErrorCode)
-	assertSnykError(t, "upload failed with authentication error", err.SnykError)
+	assertSnykError(t, "Upload failed with authentication error.", err.SnykError)
 	assert.Nil(t, resp)
 }
 
-func TestAnalyze_EmptyBundleError(t *testing.T) {
+func TestAnalyze_EmptyDirectory(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRT := httpmock.NewMockRoundTripper(ctrl)
+
+	clientFactory := func() *http.Client {
+		return &http.Client{
+			Transport: mockRT,
+		}
+	}
+
+	logger := loggermock.NewNoOpLogger()
+	ictx := frameworkmock.NewMockInvocationContext(t)
+
+	codeService := code.NewCodeServiceImpl()
+
+	mockFiltersSuccess(mockRT)
+	mockBundleHTTPError(mockRT, fmt.Errorf("no files to scan"))
+
+	resp, _, err := codeService.Analyze(getDir(), clientFactory, logger, ictx.GetConfiguration(), ictx.GetUserInterface())
+
+	assert.Equal(t, "SNYK-AI-BOM-0003", err.SnykError.ErrorCode)
+	assert.Nil(t, resp)
+}
+
+func TestAnalyze_NoSupportedFiles(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -153,7 +179,6 @@ func TestAnalyze_EmptyBundleError(t *testing.T) {
 	resp, _, err := codeService.Analyze(getDir(), clientFactory, logger, ictx.GetConfiguration(), ictx.GetUserInterface())
 
 	assert.Equal(t, "SNYK-AI-BOM-0003", err.SnykError.ErrorCode)
-	assertSnykError(t, "empty bundle hash", err.SnykError)
 	assert.Nil(t, resp)
 }
 
@@ -181,7 +206,7 @@ func TestAnalyze_AnalysisAuthZError(t *testing.T) {
 	resp, _, err := codeService.Analyze(getDir(), clientFactory, logger, ictx.GetConfiguration(), ictx.GetUserInterface())
 
 	assert.Equal(t, "SNYK-AI-BOM-0002", err.SnykError.ErrorCode)
-	assertSnykError(t, "analysis request failed with status code 403", err.SnykError)
+	assertSnykError(t, "Analysis request failed with status code 403.", err.SnykError)
 	assert.Nil(t, resp)
 }
 
@@ -209,7 +234,7 @@ func TestAnalyze_AnalysisHTTPError(t *testing.T) {
 	resp, _, err := codeService.Analyze(getDir(), clientFactory, logger, ictx.GetConfiguration(), ictx.GetUserInterface())
 
 	assert.Equal(t, "SNYK-AI-BOM-0001", err.SnykError.ErrorCode)
-	assertSnykError(t, "analysis request HTTP error", err.SnykError)
+	assertSnykError(t, "Analysis request HTTP error.", err.SnykError)
 	assert.Nil(t, resp)
 }
 
@@ -237,7 +262,7 @@ func TestAnalyze_AnalysisFailure(t *testing.T) {
 	resp, _, err := codeService.Analyze(getDir(), clientFactory, logger, ictx.GetConfiguration(), ictx.GetUserInterface())
 
 	assert.Equal(t, "SNYK-AI-BOM-0001", err.SnykError.ErrorCode)
-	assertSnykError(t, "analysis has completed with status: FAILED", err.SnykError)
+	assertSnykError(t, "Analysis has completed with status: FAILED.", err.SnykError)
 	assert.Nil(t, resp)
 }
 


### PR DESCRIPTION
### ❓ What does this change do?

Polishes some errors:
- Makes them capitalised & finishes them with a period

Added error handling & a test for scanning a totally empty directory