### PR TITLE
fix: snyk config file [AIBOM-84]

### DIFF
--- a/internal/services/code/code.go
+++ b/internal/services/code/code.go
@@ -284,6 +284,10 @@ func getFilesForPath(path string, logger *zerolog.Logger, maxThreads int) (<-cha
 	filter := frameworkUtils.NewFileFilter(path, logger, frameworkUtils.WithThreadNumber(maxThreads))
 
 	rules, err := filter.GetRules([]string{".gitignore", ".dcignore", ".snyk"})
+	// There seems to be an issue with GetRules where .snyk files are not being excluded.
+	// We can manually add this glob rule as a stop-gap.
+	rules = append(rules, "**/.[Ss][Nn][Yy][Kk]/**")
+	logger.Debug().Strs("filter_rules", rules).Msg("File filter rules")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get file filter rules: %w", err)
 	}


### PR DESCRIPTION
### ❓ What does this change do?

.snyk files are being sent to aibom suggest. Even though they are not meant to be. This is possibly caused by a bug in github.com/snyk/go-application-framework `filter.GetRules` function.

While looking into that bug, we can fix the problem by manually exluding snyk files.

More detail into the investigation can be found in the [JIRA ticket](https://snyksec.atlassian.net/browse/AIBOM-84)
