### PR TITLE
fix: handle sarif error [AIBOM-84]

### DIFF
--- a/internal/commands/aibomcreate/aibomcreate.go
+++ b/internal/commands/aibomcreate/aibomcreate.go
@@ -127,7 +127,8 @@ func extractAiBomFromResult(response *code.AnalysisResponse, logger *zerolog.Log
 		if strings.Contains(result.Message.Text, "bomFormat") {
 			aiBomResults = append(aiBomResults, result)
 		} else {
-			logger.Warn().Msgf("unexpected result level: %s, ruleId: %s, message: %s", result.Level, result.RuleID, result.Message.Text)
+			logger.Warn().Msgf("unexpected result - level: %s, ruleId: %s, files: %s, message: %s",
+				result.Level, result.RuleID, buildLocationURIs(result.Locations), result.Message.Text)
 		}
 	}
 	if len(aiBomResults) != 1 {
@@ -135,6 +136,17 @@ func extractAiBomFromResult(response *code.AnalysisResponse, logger *zerolog.Log
 		return "", goErrors.New("Failed to extract AI-BOM from result.")
 	}
 	return aiBomResults[0].Message.Text, nil
+}
+
+func buildLocationURIs(locations []code.SarifLocation) string {
+	var uris []string
+	for _, loc := range locations {
+		uri := loc.PhysicalLocation.ArtifactLocation.URI
+		if uri != "" {
+			uris = append(uris, uri)
+		}
+	}
+	return strings.Join(uris, ", ")
 }
 
 //nolint:ireturn // Unable to change return type of external library

--- a/internal/commands/aibomcreate/aibomcreate.go
+++ b/internal/commands/aibomcreate/aibomcreate.go
@@ -122,11 +122,19 @@ func extractAiBomFromResult(response *code.AnalysisResponse, logger *zerolog.Log
 		logger.Debug().Msgf("Failed to extract AI-BOM from result, %d runs in result, expected 1", len(response.Sarif.Runs))
 		return "", goErrors.New("Failed to extract AI-BOM from result.")
 	}
-	if len(response.Sarif.Runs[0].Results) != 1 {
-		logger.Debug().Msgf("Failed to extract AI-BOM from result, %d results in Runs[0], expected 1", len(response.Sarif.Runs[0].Results))
+	var aiBomResults []code.SarifResult
+	for _, result := range response.Sarif.Runs[0].Results {
+		if strings.Contains(result.Message.Text, "bomFormat") {
+			aiBomResults = append(aiBomResults, result)
+		} else {
+			logger.Warn().Msgf("unexpected result level: %s, ruleId: %s, message: %s", result.Level, result.RuleID, result.Message.Text)
+		}
+	}
+	if len(aiBomResults) != 1 {
+		logger.Debug().Msgf("Failed to extract AI-BOM from result, %d results in Runs[0], expected 1", len(aiBomResults))
 		return "", goErrors.New("Failed to extract AI-BOM from result.")
 	}
-	return response.Sarif.Runs[0].Results[0].Message.Text, nil
+	return aiBomResults[0].Message.Text, nil
 }
 
 //nolint:ireturn // Unable to change return type of external library

--- a/internal/services/code/sarif.go
+++ b/internal/services/code/sarif.go
@@ -5,6 +5,8 @@ type SarifMessage struct {
 }
 
 type SarifResult struct {
+	RuleID  string       `json:"ruleId"`
+	Level   string       `json:"level"`
 	Message SarifMessage `json:"message"`
 }
 

--- a/internal/services/code/sarif.go
+++ b/internal/services/code/sarif.go
@@ -4,10 +4,24 @@ type SarifMessage struct {
 	Text string `json:"text"`
 }
 
+type SarifArtifactLocation struct {
+	URI       string `json:"uri"`
+	URIBaseID string `json:"uriBaseId"`
+}
+
+type SarifPhysicalLocation struct {
+	ArtifactLocation SarifArtifactLocation `json:"artifactLocation"`
+}
+
+type SarifLocation struct {
+	PhysicalLocation SarifPhysicalLocation `json:"physicalLocation"`
+}
+
 type SarifResult struct {
-	RuleID  string       `json:"ruleId"`
-	Level   string       `json:"level"`
-	Message SarifMessage `json:"message"`
+	RuleID    string          `json:"ruleId"`
+	Level     string          `json:"level"`
+	Message   SarifMessage    `json:"message"`
+	Locations []SarifLocation `json:"locations"`
 }
 
 type SarifRun struct {


### PR DESCRIPTION
### ❓ What does this change do?

Suggest can send us errors in the sarif - e.g. when there is an invalid .snyk file. These should not be fatal for the scan. This PR handles the errors by filtering them out of the SBOM & adding warning logs visible only when debugging.
