### PR TITLE
chore: adding api availability check to fail fast

### DIFF
--- a/internal/commands/aibomcreate/aibomcreate.go
+++ b/internal/commands/aibomcreate/aibomcreate.go
@@ -71,6 +71,17 @@ func RunAiBomWorkflow(
 		return nil, errors.NewCommandIsExperimentalError().SnykError
 	}
 
+	ctx := context.Background()
+	orgID := config.GetString(configuration.ORGANIZATION)
+
+	logger.Debug().Msg("checking api availability")
+	aiBomErr := aiBomClient.CheckAPIAvailability(ctx, orgID)
+
+	if aiBomErr != nil {
+		logger.Debug().Msg("api availability check failed")
+		return nil, aiBomErr.SnykError
+	}
+
 	logger.Debug().Msg("AI BOM workflow start")
 
 	depGraphResult, err := depgraphService.GetDepgraph(invocationCtx)
@@ -98,9 +109,6 @@ func RunAiBomWorkflow(
 		return nil, bundleErr.SnykError
 	}
 
-	ctx := context.Background()
-
-	orgID := config.GetString(configuration.ORGANIZATION)
 	aiBomDoc, aiBomErr := aiBomClient.GenerateAIBOM(ctx, orgID, bundleHash)
 	if aiBomErr != nil {
 		logger.Debug().Err(aiBomErr.SnykError).Msg("error while generating AI-BOM")

--- a/internal/commands/aibomcreate/aibomcreate_test.go
+++ b/internal/commands/aibomcreate/aibomcreate_test.go
@@ -118,6 +118,7 @@ func TestAiBomWorkflow_APIUnavailable(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ictx.GetConfiguration().Set(utils.FlagExperimental, true)
 	mockCodeService := codemock.NewMockCodeService(ctrl)
+	mockCodeService.EXPECT().UploadBundle(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	mockDepgraphService := depgraphmock.NewMockDepgraphService(ctrl)
 	aiBomClient := aibomclientmock.NewMockAiBomClient(ctrl)
 	unavailableError := errors.NewInternalError("unavailable")

--- a/internal/services/ai-bom-client/client.go
+++ b/internal/services/ai-bom-client/client.go
@@ -17,8 +17,13 @@ import (
 	errors "github.com/snyk/cli-extension-ai-bom/internal/errors"
 )
 
+const (
+	DryRunBundleHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)
+
 //revive:disable:exported // The interface must be called AiBomClient to standardize.
 type AiBomClient interface {
+	CheckAPIAvailability(ctx context.Context, orgID string) *errors.AiBomError
 	GenerateAIBOM(
 		ctx context.Context,
 		orgID,
@@ -62,6 +67,11 @@ func NewAiBomClient(
 }
 
 var APIVersion = "2024-10-15"
+
+func (c *AIBOMClientImpl) CheckAPIAvailability(ctx context.Context, orgID string) *errors.AiBomError {
+	_, err := c.createAIBOM(ctx, orgID, DryRunBundleHash)
+	return err
+}
 
 func (c *AIBOMClientImpl) GenerateAIBOM(ctx context.Context, orgID, bundleHash string) (string, *errors.AiBomError) {
 	jobID, err := c.createAIBOM(ctx, orgID, bundleHash)

--- a/mocks/aibomclientmock/client_mock.go
+++ b/mocks/aibomclientmock/client_mock.go
@@ -41,6 +41,20 @@ func (m *MockAiBomClient) EXPECT() *MockAiBomClientMockRecorder {
 	return m.recorder
 }
 
+// CheckAPIAvailability mocks base method.
+func (m *MockAiBomClient) CheckAPIAvailability(ctx context.Context, orgID string) *errors.AiBomError {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckAPIAvailability", ctx, orgID)
+	ret0, _ := ret[0].(*errors.AiBomError)
+	return ret0
+}
+
+// CheckAPIAvailability indicates an expected call of CheckAPIAvailability.
+func (mr *MockAiBomClientMockRecorder) CheckAPIAvailability(ctx, orgID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckAPIAvailability", reflect.TypeOf((*MockAiBomClient)(nil).CheckAPIAvailability), ctx, orgID)
+}
+
 // GenerateAIBOM mocks base method.
 func (m *MockAiBomClient) GenerateAIBOM(ctx context.Context, orgID, bundleHash string) (string, *errors.AiBomError) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### ❓ What does this change do?

Fail before building DepGraphs or uploading FileBundles in case the API is unavailable.
