### PR TITLE
fix: error handling [AIRT-42]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 pkg/redteam @snyk/ai-redteaming-agent
 internal/commands/redteam @snyk/ai-redteaming-agent
 internal/services/red-team-client @snyk/ai-redteaming-agent
+internal/errors/redteam @snyk/ai-redteaming-agent

--- a/internal/commands/redteam/redteam.go
+++ b/internal/commands/redteam/redteam.go
@@ -134,7 +134,7 @@ func handleRunScanCommand(invocationCtx workflow.InvocationContext, redTeamClien
 	return getScanResults(ctx, logger, redTeamClient, orgID, scanID)
 }
 
-//nolint:ireturn // Unable to change return type of external library
+//nolint:ireturn,nolintlint // Unable to change return type of external library
 func loadAndValidateConfig(logger *zerolog.Logger, config configuration.Configuration) (*redteamclient.RedTeamConfig, []workflow.Data, error) {
 	configPath := config.GetString(utils.FlagConfig)
 	if configPath == "" {

--- a/internal/commands/redteam/redteam.go
+++ b/internal/commands/redteam/redteam.go
@@ -121,7 +121,7 @@ func handleRunScanCommand(invocationCtx workflow.InvocationContext, redTeamClien
 	}
 
 	if scanStatus.Status == redteamclient.AIScanStatusFailed {
-		return nil, handleScanFailure(scanStatus)
+		return nil, handleScanFailure(scanStatus, scanID)
 	}
 
 	progressBar.SetTitle("Scan completed")
@@ -185,18 +185,18 @@ or use the --config flag to specify a custom path.`
 	return clientConfig, nil, nil
 }
 
-func handleScanFailure(scanStatus *redteamclient.AIScan) *redteam_errors.RedTeamError {
+func handleScanFailure(scanStatus *redteamclient.AIScan, scanID string) *redteam_errors.RedTeamError {
 	if len(scanStatus.Feedback.Error) > 0 {
 		backendError := scanStatus.Feedback.Error[0]
 		switch backendError.Code {
 		case "context_error":
 			return redteam_errors.NewBadRequestError(backendError.Message)
 		default:
-			return redteam_errors.NewScanError("type: " + backendError.Code + ", message: " + backendError.Message)
+			return redteam_errors.NewScanError("type: "+backendError.Code+", message: "+backendError.Message, scanID)
 		}
 	}
 
-	return redteam_errors.NewScanError("We could't determine the details. Contact support for more information.")
+	return redteam_errors.NewScanError("We could't determine the details. Contact support for more information.", scanID)
 }
 
 //nolint:ireturn // Unable to change return type of external library

--- a/internal/commands/redteam/test-redteam.yaml
+++ b/internal/commands/redteam/test-redteam.yaml
@@ -1,0 +1,10 @@
+
+target:
+  name: "Test Target"
+  type: api
+  context:
+    purpose: "Testing chatbot"
+  settings:
+    url: "https://example.com"
+    response_selector: "response"
+    request_body_template: "{\"message\": \"{{prompt}}\"}"

--- a/internal/commands/redteam/testdata/redteam.yaml
+++ b/internal/commands/redteam/testdata/redteam.yaml
@@ -1,10 +1,9 @@
-
 target:
-  name: "Test Target"
+  name: "Default Config"
   type: api
   context:
     purpose: "Testing chatbot"
   settings:
     url: "https://example.com"
     response_selector: "response"
-    request_body_template: "{\"message\": \"{{prompt}}\"}"
+    request_body_template: '{"message": "{{prompt}}"}'

--- a/internal/errors/redteam/errors.go
+++ b/internal/errors/redteam/errors.go
@@ -1,0 +1,68 @@
+package redteam
+
+import (
+	"fmt"
+
+	snyk_common_errors "github.com/snyk/error-catalog-golang-public/snyk"
+)
+
+// The below pattern has been borrowed from cli-extension-os-flows.
+// The issue with SnykError is that it serializes to a Title (that can't be changed)
+// rather than the msg provided.
+
+// TODO(pkey): address above by moving to a generic error-catalog interface.
+//
+//nolint:revive // RedTeamError is intentionally named to match package context
+type RedTeamError struct {
+	err     error
+	userMsg string
+}
+
+// This will show up in the details of the error in the CLI.
+func (xerr RedTeamError) Error() string {
+	return xerr.userMsg
+}
+
+// Unwrap implements error.
+// NOTE: If an untyped (non-Snyk) error is wrapped, it will be shown
+// to the user as Unspecified Error (SNYK-CLI-0000).
+func (xerr RedTeamError) Unwrap() error {
+	return xerr.err
+}
+
+// newRedTeamError creates a new RedTeamError.
+func newRedTeamError(err error, userMsg string) *RedTeamError {
+	return &RedTeamError{
+		err:     err,
+		userMsg: userMsg,
+	}
+}
+
+func NewBadRequestError(msg string) *RedTeamError {
+	return newRedTeamError(snyk_common_errors.NewBadRequestError(msg), msg)
+}
+
+func NewScanError(msg string) *RedTeamError {
+	return newRedTeamError(fmt.Errorf("Red Teaming scan failed. See details for more information."), msg)
+}
+
+func NewServerError(msg string) *RedTeamError {
+	return newRedTeamError(snyk_common_errors.NewServerError(msg), msg)
+}
+
+func NewHTTPClientError(msg string) *RedTeamError {
+	return newRedTeamError(snyk_common_errors.NewServerError(msg), msg)
+}
+
+func NewPollingTimeoutError() *RedTeamError {
+	msg := "We couldn't get the scan results in time. Please try again or contact support."
+	return newRedTeamError(snyk_common_errors.NewTimeoutError(msg), msg)
+}
+
+func NewGenericRedTeamError(msg string, err error) *RedTeamError {
+	return newRedTeamError(err, msg)
+}
+
+func NewUnauthorizedError(msg string) *RedTeamError {
+	return newRedTeamError(snyk_common_errors.NewUnauthorisedError(msg), msg)
+}

--- a/internal/errors/redteam/errors.go
+++ b/internal/errors/redteam/errors.go
@@ -3,6 +3,7 @@ package redteam
 import (
 	"fmt"
 
+	cli_errors "github.com/snyk/error-catalog-golang-public/cli"
 	snyk_common_errors "github.com/snyk/error-catalog-golang-public/snyk"
 )
 
@@ -42,8 +43,8 @@ func NewBadRequestError(msg string) *RedTeamError {
 	return newRedTeamError(snyk_common_errors.NewBadRequestError(msg), msg)
 }
 
-func NewScanError(msg string) *RedTeamError {
-	return newRedTeamError(fmt.Errorf("Red Teaming scan failed. See details for more information."), msg)
+func NewScanError(msg, scanID string) *RedTeamError {
+	return newRedTeamError(fmt.Errorf("Red Teaming scan (ID: %s) failed. See details for more information.", scanID), msg)
 }
 
 func NewServerError(msg string) *RedTeamError {
@@ -51,7 +52,7 @@ func NewServerError(msg string) *RedTeamError {
 }
 
 func NewHTTPClientError(msg string) *RedTeamError {
-	return newRedTeamError(snyk_common_errors.NewServerError(msg), msg)
+	return newRedTeamError(cli_errors.NewGeneralCLIFailureError(msg), msg)
 }
 
 func NewPollingTimeoutError() *RedTeamError {

--- a/internal/errors/redteam/errors.go
+++ b/internal/errors/redteam/errors.go
@@ -51,6 +51,10 @@ func NewServerError(msg string) *RedTeamError {
 	return newRedTeamError(snyk_common_errors.NewServerError(msg), msg)
 }
 
+func NewForbiddenError(msg string) *RedTeamError {
+	return newRedTeamError(snyk_common_errors.NewUnauthorisedError(msg), msg)
+}
+
 func NewHTTPClientError(msg string) *RedTeamError {
 	return newRedTeamError(cli_errors.NewGeneralCLIFailureError(msg), msg)
 }

--- a/internal/errors/redteam/errors.go
+++ b/internal/errors/redteam/errors.go
@@ -44,7 +44,25 @@ func NewBadRequestError(msg string) *RedTeamError {
 }
 
 func NewScanError(msg, scanID string) *RedTeamError {
-	return newRedTeamError(fmt.Errorf("Red Teaming scan (ID: %s) failed. See details for more information.", scanID), msg)
+	return newRedTeamError(cli_errors.NewGeneralCLIFailureError(fmt.Sprintf("Scan ID: %s failed. %s", scanID, msg)), msg)
+}
+
+func NewScanContextError(msg, scanID string) *RedTeamError {
+	errorMsg := fmt.Sprintf(
+		"Scan ID: %s failed. %s",
+		scanID,
+		msg,
+	)
+	return newRedTeamError(snyk_common_errors.NewBadRequestError(errorMsg), msg)
+}
+
+func NewScanNetworkError(msg, scanID string) *RedTeamError {
+	errorMsg := fmt.Sprintf(
+		"Scan ID: %s failed. We have issues reaching your target. Here are the details: %s",
+		scanID,
+		msg,
+	)
+	return newRedTeamError(snyk_common_errors.NewBadRequestError(errorMsg), msg)
 }
 
 func NewServerError(msg string) *RedTeamError {

--- a/mocks/redteamclientmock/client_mock.go
+++ b/mocks/redteamclientmock/client_mock.go
@@ -13,8 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
+	redteam_errors "github.com/snyk/cli-extension-ai-bom/internal/errors/redteam"
 	redteamclient "github.com/snyk/cli-extension-ai-bom/internal/services/red-team-client"
-	snyk_errors "github.com/snyk/error-catalog-golang-public/snyk_errors"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -43,11 +43,11 @@ func (m *MockRedTeamClient) EXPECT() *MockRedTeamClientMockRecorder {
 }
 
 // CreateScan mocks base method.
-func (m *MockRedTeamClient) CreateScan(ctx context.Context, orgID string, config *redteamclient.RedTeamConfig) (string, *snyk_errors.Error) {
+func (m *MockRedTeamClient) CreateScan(ctx context.Context, orgID string, config *redteamclient.RedTeamConfig) (string, *redteam_errors.RedTeamError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateScan", ctx, orgID, config)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(*snyk_errors.Error)
+	ret1, _ := ret[1].(*redteam_errors.RedTeamError)
 	return ret0, ret1
 }
 
@@ -58,11 +58,11 @@ func (mr *MockRedTeamClientMockRecorder) CreateScan(ctx, orgID, config any) *gom
 }
 
 // GetScan mocks base method.
-func (m *MockRedTeamClient) GetScan(ctx context.Context, orgID, scanID string) (*redteamclient.AIScan, *snyk_errors.Error) {
+func (m *MockRedTeamClient) GetScan(ctx context.Context, orgID, scanID string) (*redteamclient.AIScan, *redteam_errors.RedTeamError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetScan", ctx, orgID, scanID)
 	ret0, _ := ret[0].(*redteamclient.AIScan)
-	ret1, _ := ret[1].(*snyk_errors.Error)
+	ret1, _ := ret[1].(*redteam_errors.RedTeamError)
 	return ret0, ret1
 }
 
@@ -73,11 +73,11 @@ func (mr *MockRedTeamClientMockRecorder) GetScan(ctx, orgID, scanID any) *gomock
 }
 
 // GetScanResults mocks base method.
-func (m *MockRedTeamClient) GetScanResults(ctx context.Context, orgID, scanID string) (redteamclient.GetAIVulnerabilitiesResponseData, *snyk_errors.Error) {
+func (m *MockRedTeamClient) GetScanResults(ctx context.Context, orgID, scanID string) (redteamclient.GetAIVulnerabilitiesResponseData, *redteam_errors.RedTeamError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetScanResults", ctx, orgID, scanID)
 	ret0, _ := ret[0].(redteamclient.GetAIVulnerabilitiesResponseData)
-	ret1, _ := ret[1].(*snyk_errors.Error)
+	ret1, _ := ret[1].(*redteam_errors.RedTeamError)
 	return ret0, ret1
 }
 

--- a/mocks/redteamclientmock/client_mock.go
+++ b/mocks/redteamclientmock/client_mock.go
@@ -42,6 +42,21 @@ func (m *MockRedTeamClient) EXPECT() *MockRedTeamClientMockRecorder {
 	return m.recorder
 }
 
+// CreateScan mocks base method.
+func (m *MockRedTeamClient) CreateScan(ctx context.Context, orgID string, config *redteamclient.RedTeamConfig) (string, *snyk_errors.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateScan", ctx, orgID, config)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(*snyk_errors.Error)
+	return ret0, ret1
+}
+
+// CreateScan indicates an expected call of CreateScan.
+func (mr *MockRedTeamClientMockRecorder) CreateScan(ctx, orgID, config any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateScan", reflect.TypeOf((*MockRedTeamClient)(nil).CreateScan), ctx, orgID, config)
+}
+
 // GetScan mocks base method.
 func (m *MockRedTeamClient) GetScan(ctx context.Context, orgID, scanID string) (*redteamclient.AIScan, *snyk_errors.Error) {
 	m.ctrl.T.Helper()
@@ -70,19 +85,4 @@ func (m *MockRedTeamClient) GetScanResults(ctx context.Context, orgID, scanID st
 func (mr *MockRedTeamClientMockRecorder) GetScanResults(ctx, orgID, scanID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScanResults", reflect.TypeOf((*MockRedTeamClient)(nil).GetScanResults), ctx, orgID, scanID)
-}
-
-// RunScan mocks base method.
-func (m *MockRedTeamClient) RunScan(ctx context.Context, orgID string, config *redteamclient.RedTeamConfig) (string, *snyk_errors.Error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunScan", ctx, orgID, config)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(*snyk_errors.Error)
-	return ret0, ret1
-}
-
-// RunScan indicates an expected call of RunScan.
-func (mr *MockRedTeamClientMockRecorder) RunScan(ctx, orgID, config any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunScan", reflect.TypeOf((*MockRedTeamClient)(nil).RunScan), ctx, orgID, config)
 }


### PR DESCRIPTION
### ❓ What does this change do?

Improves error handling from UX point of view.

<details>
  <summary>Examples below</summary>
 <img width="734" height="202" alt="image" src="https://github.com/user-attachments/assets/6c60ed9c-4db4-4432-9a4c-4f2bb2bc8372" />

<img width="693" height="173" alt="image" src="https://github.com/user-attachments/assets/437d23c0-ef3e-46bd-b24d-eb1752fa1350" />

<img width="761" height="191" alt="image" src="https://github.com/user-attachments/assets/2e0db0cc-13d1-4c21-bda5-225153ad4f5c" />

</details>

Also:
 - separated the responsibilities: `redteam/client.go` is now simply and API wrapper and doesn't contain any additional logic like polling. The logic has been moved to the `commands/redteam.go`
 - added us to be COs of `errors/redteam` to not bother `aibom` folks.

