### PR TITLE
fix: handle properly 400s and 500s [AIRT-47]

### DIFF
--- a/internal/services/red-team-client/client.go
+++ b/internal/services/red-team-client/client.go
@@ -230,8 +230,8 @@ func (c *ClientImpl) redTeamErrorFromHTTPStatusCode(endPoint string, statusCode 
 	}
 }
 
-// Handles HttpClient errors. Snyk's HttpClient overrides the logic that would return a non-nil if response that has a valid status code
-// therefore we need to handle it here.
+// Handles HttpClient errors. Snyk's HttpClient overrides the logic that would return a non-nil response that has a valid status code
+// Instead, it returns a snyk_errors.Error object. This handles that error as a http client error.
 func (c *ClientImpl) redTeamErrorFromHTTPClientError(endPoint string, err error) *redteam_errors.RedTeamError {
 	c.logger.Debug().Err(err).Msg(fmt.Sprintf("%s request HTTP error", endPoint))
 


### PR DESCRIPTION
### ❓ What does this change do?

If it's a `400`, pass it through and display the message that came from the backend. This allows for more flexibility in the future and us defining errors in the backend rather than releasing the client code each time.

In this particular case, it enables us seeing the concurrent requests error:

<img width="986" height="189" alt="image" src="https://github.com/user-attachments/assets/e093a513-8ddb-40d7-b9cb-de74a98972ef" />
