### PR TITLE
fix: increase polling limit and properly output instructions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -141,3 +141,15 @@ linters-settings:
   stylecheck:
     checks: ["all", "-ST1005"] # ST1005 requires all error messages to start with lower case characters. This conflicts with Snyk's public error message standards.
     http-status-code-whitelist: []
+
+# NOTE(pkey): Can't change the return types so ignoring.
+issues:
+  exclude-rules:
+    - path: internal/commands/redteam/redteam.go
+      linters:
+        - ireturn
+      text: "setupProgressBar returns interface"
+    - path: internal/commands/redteam/redteam.go
+      linters:
+        - ireturn
+      text: "newWorkflowData returns interface"

--- a/internal/commands/redteamscanningagent/redteamscanningagent.go
+++ b/internal/commands/redteamscanningagent/redteamscanningagent.go
@@ -182,6 +182,7 @@ func handleCreateScanningAgent(invocationCtx workflow.InvocationContext, redTeam
 	logger := invocationCtx.GetEnhancedLogger()
 	config := invocationCtx.GetConfiguration()
 	ctx := context.Background()
+	ui := invocationCtx.GetUserInterface()
 
 	scanningAgentName := config.GetString(utils.FlagScanningAgentName)
 	if scanningAgentName == "" {
@@ -205,6 +206,10 @@ func handleCreateScanningAgent(invocationCtx workflow.InvocationContext, redTeam
 
 	logger.Info().Msgf("Scanning agent config generated for agent with ID: %s", scanningAgent.ID)
 
+	if err := ui.Output(ScanningAgentConfigMessage(scanningAgentConfig.FarcasterAgentToken, scanningAgentConfig.FarcasterAPIURL)); err != nil {
+		logger.Debug().Err(err).Msg("error while outputting scanning agent config message")
+	}
+
 	agentBytes, err := json.Marshal(scanningAgent)
 	if err != nil {
 		logger.Debug().Err(err).Msg("error while marshaling scanning agent")
@@ -213,14 +218,6 @@ func handleCreateScanningAgent(invocationCtx workflow.InvocationContext, redTeam
 
 	workflowData := []workflow.Data{
 		newWorkflowData(scanningAgentCreateWorkflowType, "application/json", agentBytes),
-		newWorkflowData(
-			scanningAgentCreateWorkflowType,
-			"text/plain",
-			[]byte(ScanningAgentConfigMessage(
-				scanningAgentConfig.FarcasterAgentToken,
-				scanningAgentConfig.FarcasterAPIURL,
-			)),
-		),
 	}
 	return workflowData, nil
 }

--- a/internal/errors/redteam/errors.go
+++ b/internal/errors/redteam/errors.go
@@ -78,7 +78,7 @@ func NewHTTPClientError(msg string) *RedTeamError {
 }
 
 func NewPollingTimeoutError() *RedTeamError {
-	msg := "We couldn't get the scan results in time. Please try again or contact support."
+	msg := "We couldn't get the scan results in a reasonable time. Please try again or contact support."
 	return newRedTeamError(snyk_common_errors.NewTimeoutError(msg), msg)
 }
 


### PR DESCRIPTION
1. Increase limit to 24h which should never be reached at least as things stand now. We still want some limit in case a zombie process on user's end doesn't exit and polls forever. 
2. Outputs instructions to setup farcaster.