### PR TITLE
fix: add back pervious glob filters

### DIFF
--- a/internal/commands/aibomcreate/aibomcreate.go
+++ b/internal/commands/aibomcreate/aibomcreate.go
@@ -167,13 +167,13 @@ func filterAndUploadFiles(ctx context.Context, client fileupload.Client, logger 
 
 	textFilesFilter := filefilter.NewPipeline(
 		filefilter.WithConcurrency(runtime.NumCPU()),
+		// we only want to upload files that are not excluded by the rules
 		filefilter.WithExcludeGlobs(rules),
 		filefilter.WithFilters(
 			// The file upload api only supports files up to 50mb
 			filefilter.FileSizeFilter(logger),
 			// we only want to upload text files
 			filefilter.TextFileOnlyFilter(logger),
-			// we only want to upload files that are not excluded by the rules
 		),
 		filefilter.WithLogger(logger),
 	)


### PR DESCRIPTION
### ❓ What does this change do?

- Adds back previous filters that we had
- return a no supported files error when no files are provided for upload
