### PR TITLE
feat: partial success error msg

### DIFF
--- a/internal/commands/redteam/redteam.go
+++ b/internal/commands/redteam/redteam.go
@@ -262,19 +262,19 @@ func handleScanFailure(scanStatus *redteamclient.AIScan, scanID string) *redteam
 
 	if len(scanStatus.Feedback.Error) > 0 {
 		backendError := scanStatus.Feedback.Error[0]
+		message := backendError.Message + hint
 
 		switch backendError.Code {
 		case "context_error":
-			return redteam_errors.NewScanContextError(backendError.Message+hint, scanID)
+			return redteam_errors.NewScanContextError(message, scanID)
 		case "network_error":
-			return redteam_errors.NewScanNetworkError(backendError.Message+hint, scanID)
+			return redteam_errors.NewScanNetworkError(message, scanID)
 		default:
 			errorMsg := fmt.Sprintf(
-				"Red teaming scan (ID: %s) failed. \nError type: %s \nMessage: %s%s",
+				"Red teaming scan (ID: %s) failed. \nError type: %s \nMessage: %s",
 				scanID,
 				backendError.Code,
-				backendError.Message,
-				hint,
+				message,
 			)
 			return redteam_errors.NewScanError(errorMsg, scanID)
 		}


### PR DESCRIPTION
### ❓ What does this change do?
Adds a hint instructing users to use `--get` command, to error messages when a scan fails but has already found vulnerabilities.

<img width="654" height="424" alt="image" src="https://github.com/user-attachments/assets/820f67bb-bc76-4726-bfcc-ed596c4d4f82" />
