### PR TITLE
chore: support severity threshold

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/oapi-codegen/runtime v1.1.2
 	github.com/rs/zerolog v1.34.0
+	github.com/samber/lo v1.53.0
 	github.com/snyk/cli-extension-secrets v0.0.0-20260126084440-33e481bd7ae2
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260108110943-21ad0c940c14
 	github.com/snyk/go-application-framework v0.0.0-20260112170304-1a9b38fae0bc
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/mock v0.5.2
-	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDj
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
+github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
+github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/internal/commands/aibomcreate/aibomcreate.go
+++ b/internal/commands/aibomcreate/aibomcreate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/snyk/go-application-framework/pkg/apiclients/fileupload"
 	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/content_type"
 	frameworkUtils "github.com/snyk/go-application-framework/pkg/utils"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
@@ -89,9 +90,9 @@ func AiBomWorkflow(invocationCtx workflow.InvocationContext, _ []workflow.Data) 
 //go:embed aibom.html
 var htmlTemplate string
 
-func returnRawJSON(jsonOutput string) []workflow.Data {
-	workflowData := newWorkflowData("application/json", []byte(jsonOutput))
-	return []workflow.Data{workflowData}
+//nolint:ireturn // workflow.Data is an interface from external library; cannot change return type
+func rawJSONData(jsonOutput string) workflow.Data {
+	return newWorkflowData("application/json", []byte(jsonOutput))
 }
 
 // runTestFlow runs the CLI policy test and returns workflow data (raw JSON or pretty output).
@@ -111,22 +112,28 @@ func runTestFlow(
 		return nil, testErr.SnykError
 	}
 	logger.Debug().Msg("Successfully tested AI-BOM")
-	if jsonOutput {
-		logger.Debug().Msg("json output flag is set, skipping pretty output")
-		return returnRawJSON(testResult), nil
-	}
 	parsed, parseErr := ParseTestResult(testResult)
 	if parseErr != nil {
 		logger.Debug().Err(parseErr).Msg("failed to parse test result, returning raw JSON")
-		return returnRawJSON(testResult), nil
+		return nil, errors.NewInternalError("error while parsing AI-BOM test result").SnykError
+	}
+	summaryData := workflow.NewData(
+		workflow.NewTypeIdentifier(WorkflowIDTest, "test-summary"),
+		content_type.TEST_SUMMARY,
+		parsed.Summary,
+	)
+	dataToReturn := []workflow.Data{summaryData}
+	if jsonOutput {
+		logger.Debug().Msg("json output flag is set, skipping pretty output")
+		return append(dataToReturn, rawJSONData(testResult)), nil
 	}
 	var prettyBuf bytes.Buffer
 	if err := RenderPrettyResult(invocationCtx, &prettyBuf, parsed); err != nil {
 		logger.Debug().Err(err).Msg("failed to render test result, returning raw JSON")
-		return returnRawJSON(testResult), nil
+		return append(dataToReturn, rawJSONData(testResult)), nil
 	}
 	workflowData := newWorkflowData("text/plain", prettyBuf.Bytes())
-	return []workflow.Data{workflowData}, nil
+	return append(dataToReturn, workflowData), nil
 }
 
 func RunAiBomWorkflow(

--- a/internal/commands/aibomcreate/presenter.go
+++ b/internal/commands/aibomcreate/presenter.go
@@ -1,34 +1,15 @@
 package aibomcreate
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 	"github.com/snyk/go-application-framework/pkg/workflow"
-	"golang.org/x/exp/slices"
 )
-
-// PolicyTestIssue represents a single CLI policy test issue for display.
-type PolicyTestIssue struct {
-	ID                string `json:"id"`
-	Description       string `json:"description"`
-	Severity          string `json:"severity"`
-	PolicyID          string `json:"policy_id"`
-	State             string `json:"state"`
-	Source            string `json:"source"`
-	RemediationAdvice string `json:"remediation_advice"`
-}
-
-// TestResultPresentation is the parsed test result used for pretty and JSON output.
-type TestResultPresentation struct {
-	OK      bool              `json:"ok"`
-	Issues  []PolicyTestIssue `json:"issues"`
-	Summary string            `json:"summary"`
-}
 
 // rawTestResponse mirrors the API response for parsing (snake_case).
 type rawTestResponse struct {
@@ -39,22 +20,6 @@ type rawTestResponse struct {
 			Issues []PolicyTestIssue `json:"issues"`
 		} `json:"attributes"`
 	} `json:"data"`
-}
-
-// severityLevel for ordering (higher = more severe).
-func severityLevel(s string) int {
-	switch strings.ToLower(s) {
-	case "critical":
-		return 4
-	case "high":
-		return 3
-	case "medium":
-		return 2
-	case "low":
-		return 1
-	default:
-		return 0
-	}
 }
 
 var (
@@ -83,45 +48,19 @@ func styleForSeverity(severity string) lipgloss.Style {
 	}
 }
 
-// ParseTestResult unmarshals the API JSON string into TestResultPresentation.
-func ParseTestResult(jsonStr string) (*TestResultPresentation, error) {
-	var raw rawTestResponse
-	if err := json.Unmarshal([]byte(jsonStr), &raw); err != nil {
-		return nil, fmt.Errorf("parse test result: %w", err)
-	}
-	issues := raw.Data.Attributes.Issues
-	slices.SortFunc(issues, func(a, b PolicyTestIssue) int {
-		sa, sb := severityLevel(a.Severity), severityLevel(b.Severity)
-		if sa != sb {
-			return sb - sa // higher severity first
-		}
-		if a.ID != b.ID {
-			return strings.Compare(a.ID, b.ID)
-		}
-		return strings.Compare(a.Description, b.Description)
-	})
-	total := len(issues)
-	summary := fmt.Sprintf("Found %d issue(s)", total)
-	if total == 0 {
-		summary = "No issues found"
-	}
-	return &TestResultPresentation{
-		OK:      total == 0,
-		Issues:  issues,
-		Summary: summary,
-	}, nil
-}
-
 // RenderPrettyResult writes a human-readable test result to w.
-func RenderPrettyResult(invocationCtx workflow.InvocationContext, w io.Writer, res *TestResultPresentation) error {
+func RenderPrettyResult(invocationCtx workflow.InvocationContext, w io.Writer, res *TestResult) error {
 	config := invocationCtx.GetConfiguration()
 	title := sectionStyle.Render("AI BOM policy test")
 	_, _ = fmt.Fprintf(w, "\n%s\n\n", title)
 
-	issuesBlock := renderIssues(config.GetString(configuration.API_URL), res.Issues)
+	openIssues := filterIssuesByState(res.Issues, "open")
+	ignoredIssues := filterIssuesByState(res.Issues, "ignored")
+
+	issuesBlock := renderIssues(config.GetString(configuration.API_URL), openIssues, ignoredIssues)
 	_, _ = fmt.Fprintln(w, issuesBlock)
 
-	summaryBlock := renderSummary(res)
+	summaryBlock := renderSummary(openIssues, ignoredIssues)
 	_, _ = fmt.Fprintln(w, boxStyle.Render(summaryBlock))
 	return nil
 }
@@ -134,12 +73,16 @@ func makePolicyURL(baseURL, policyID string) string {
 	return fmt.Sprintf("%s/policies/%s", baseURL, policyID)
 }
 
-func renderIssues(baseURL string, issues []PolicyTestIssue) string {
+func renderIssues(baseURL string, openIssues, ignoredIssues []PolicyTestIssue) string {
+	return renderIssuesForState(baseURL, "Open", openIssues) + "\n" + renderIssuesForState(baseURL, "Ignored", ignoredIssues)
+}
+
+func renderIssuesForState(baseURL, label string, issues []PolicyTestIssue) string {
 	if len(issues) == 0 {
-		return sectionStyle.Render("Open issues:") + "\n  No issues found."
+		return sectionStyle.Render(label+" issues:") + "\n  No issues found."
 	}
 	var b strings.Builder
-	b.WriteString(sectionStyle.Render("Open issues:"))
+	b.WriteString(sectionStyle.Render(label + " issues:"))
 	b.WriteString("\n")
 	for _, iss := range issues {
 		style := styleForSeverity(iss.Severity)
@@ -156,21 +99,32 @@ func renderIssues(baseURL string, issues []PolicyTestIssue) string {
 	return b.String()
 }
 
-func renderSummary(res *TestResultPresentation) string {
-	total := len(res.Issues)
-	bySev := make(map[string]int)
-	for _, iss := range res.Issues {
-		bySev[strings.ToLower(iss.Severity)]++
-	}
-	parts := []string{fmt.Sprintf("  Test summary\n  Open issues: %d", total)}
-	order := []string{"critical", "high", "medium", "low"}
-	for _, sev := range order {
-		if n := bySev[sev]; n > 0 {
-			style := styleForSeverity(sev)
-			parts = append(parts, style.Render(fmt.Sprintf("%d %s", n, strings.ToUpper(sev))))
+func renderSummary(openIssues, ignoredIssues []PolicyTestIssue) string {
+	lines := append([]string{},
+		"  Test summary",
+		renderSummaryForState("Open", openIssues),
+		renderSummaryForState("Ignored", ignoredIssues),
+	)
+	return strings.TrimRight(strings.Join(lines, "\n"), "\n")
+}
+
+func filterIssuesByState(issues []PolicyTestIssue, state string) []PolicyTestIssue {
+	var out []PolicyTestIssue
+	for _, iss := range issues {
+		if strings.EqualFold(iss.State, state) {
+			out = append(out, iss)
 		}
 	}
-	// single line like "Open issues: 2 [2 HIGH]"
+	return out
+}
+
+func renderSummaryForState(label string, issues []PolicyTestIssue) string {
+	total := len(issues)
+	bySev := make(map[string]int)
+	for _, iss := range issues {
+		bySev[strings.ToLower(iss.Severity)]++
+	}
+	order := json_schemas.DEFAULT_SEVERITIES
 	if total > 0 {
 		var counts []string
 		for _, sev := range order {
@@ -179,15 +133,7 @@ func renderSummary(res *TestResultPresentation) string {
 				counts = append(counts, style.Render(fmt.Sprintf("%d %s", n, strings.ToUpper(sev))))
 			}
 		}
-		return fmt.Sprintf("  Test summary\n  Open issues: %d [%s]", total, strings.Join(counts, " "))
+		return fmt.Sprintf("  %s issues: %d [%s]", label, total, strings.Join(counts, " "))
 	}
-	return fmt.Sprintf("  Test summary\n  Open issues: %d", total)
-}
-
-// RenderJSONResult writes the test result as JSON to w (for machine-readable output).
-func RenderJSONResult(w io.Writer, res *TestResultPresentation) error {
-	if err := json.NewEncoder(w).Encode(res); err != nil {
-		return fmt.Errorf("encode json: %w", err)
-	}
-	return nil
+	return fmt.Sprintf("  %s issues: %d", label, total)
 }

--- a/internal/commands/aibomcreate/presenter_test.go
+++ b/internal/commands/aibomcreate/presenter_test.go
@@ -1,0 +1,137 @@
+package aibomcreate_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-ai-bom/internal/commands/aibomcreate"
+	"github.com/snyk/cli-extension-ai-bom/mocks/frameworkmock"
+)
+
+func TestRenderPrettyResult_EmptyIssues(t *testing.T) {
+	ictx := frameworkmock.NewMockInvocationContext(t)
+	ictx.GetConfiguration().Set(configuration.API_URL, "https://api.snyk.io")
+
+	res := &aibomcreate.TestResult{
+		Issues:  []aibomcreate.PolicyTestIssue{},
+		Summary: []byte(`{"results":[]}`),
+	}
+	var buf bytes.Buffer
+	err := aibomcreate.RenderPrettyResult(ictx, &buf, res)
+	require.NoError(t, err)
+	out := buf.String()
+
+	assert.Contains(t, out, "AI BOM policy test")
+	assert.Contains(t, out, "Open issues:")
+	assert.Contains(t, out, "No issues found.")
+	assert.Contains(t, out, "Ignored issues:")
+	assert.Contains(t, out, "Test summary")
+}
+
+func TestRenderPrettyResult_OpenIssueWithPolicyAndRemediation(t *testing.T) {
+	ictx := frameworkmock.NewMockInvocationContext(t)
+	ictx.GetConfiguration().Set(configuration.API_URL, "https://api.snyk.io")
+
+	res := &aibomcreate.TestResult{
+		Issues: []aibomcreate.PolicyTestIssue{
+			{
+				ID:                "issue-1",
+				Description:       "Missing license file",
+				Severity:          "high",
+				PolicyID:          "pol-abc-123",
+				State:             "open",
+				RemediationAdvice: "Add a LICENSE file to the repo.",
+			},
+		},
+		Summary: []byte(`{"results":[{"severity":"high","total":1,"open":1,"ignored":0}]}`),
+	}
+	var buf bytes.Buffer
+	err := aibomcreate.RenderPrettyResult(ictx, &buf, res)
+	require.NoError(t, err)
+	out := buf.String()
+
+	assert.Contains(t, out, "Open issues:")
+	assert.Contains(t, out, "Missing license file")
+	assert.Contains(t, out, "[HIGH]")
+	assert.Contains(t, out, "https://evo.snyk.io/policies/pol-abc-123")
+	assert.Contains(t, out, "Remediation: Add a LICENSE file to the repo.")
+	assert.Contains(t, out, "Ignored issues:")
+	assert.Contains(t, out, "Test summary")
+}
+
+func TestRenderPrettyResult_PolicyURLWithoutApiHost(t *testing.T) {
+	// When API URL does not contain "api.", policy link is just the policy ID.
+	ictx := frameworkmock.NewMockInvocationContext(t)
+	ictx.GetConfiguration().Set(configuration.API_URL, "https://custom.snyk.io")
+
+	res := &aibomcreate.TestResult{
+		Issues: []aibomcreate.PolicyTestIssue{
+			{
+				ID:          "issue-1",
+				Description: "Some issue",
+				Severity:    "medium",
+				PolicyID:    "pol-xyz",
+				State:       "open",
+			},
+		},
+		Summary: []byte(`{"results":[]}`),
+	}
+	var buf bytes.Buffer
+	err := aibomcreate.RenderPrettyResult(ictx, &buf, res)
+	require.NoError(t, err)
+	out := buf.String()
+
+	assert.Contains(t, out, "Policy: pol-xyz")
+	assert.NotContains(t, out, "evo.snyk.io")
+}
+
+func TestRenderPrettyResult_OpenAndIgnoredIssues(t *testing.T) {
+	ictx := frameworkmock.NewMockInvocationContext(t)
+	ictx.GetConfiguration().Set(configuration.API_URL, "https://api.snyk.io")
+
+	res := &aibomcreate.TestResult{
+		Issues: []aibomcreate.PolicyTestIssue{
+			{ID: "1", Description: "Open one", Severity: "critical", State: "open"},
+			{ID: "2", Description: "Ignored one", Severity: "low", State: "ignored"},
+		},
+		Summary: []byte(`{"results":[]}`),
+	}
+	var buf bytes.Buffer
+	err := aibomcreate.RenderPrettyResult(ictx, &buf, res)
+	require.NoError(t, err)
+	out := buf.String()
+
+	assert.Contains(t, out, "Open issues:")
+	assert.Contains(t, out, "Open one")
+	assert.Contains(t, out, "[CRITICAL]")
+	assert.Contains(t, out, "Ignored issues:")
+	assert.Contains(t, out, "Ignored one")
+	assert.Contains(t, out, "[LOW]")
+	// Summary section shows counts per state
+	assert.Contains(t, out, "Open issues: 1")
+	assert.Contains(t, out, "Ignored issues: 1")
+}
+
+func TestRenderPrettyResult_NoPolicyLineWhenPolicyIDEmpty(t *testing.T) {
+	ictx := frameworkmock.NewMockInvocationContext(t)
+	ictx.GetConfiguration().Set(configuration.API_URL, "https://api.snyk.io")
+
+	res := &aibomcreate.TestResult{
+		Issues: []aibomcreate.PolicyTestIssue{
+			{ID: "1", Description: "No policy", Severity: "medium", State: "open", PolicyID: ""},
+		},
+		Summary: []byte(`{"results":[]}`),
+	}
+	var buf bytes.Buffer
+	err := aibomcreate.RenderPrettyResult(ictx, &buf, res)
+	require.NoError(t, err)
+	out := buf.String()
+
+	assert.Contains(t, out, "No policy")
+	// Presenter only writes "  Policy: ..." when PolicyID is non-empty.
+	assert.NotContains(t, out, "  Policy: ")
+}

--- a/internal/commands/aibomcreate/testresultparser.go
+++ b/internal/commands/aibomcreate/testresultparser.go
@@ -1,0 +1,93 @@
+package aibomcreate
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/samber/lo"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
+)
+
+// PolicyTestIssue represents a single CLI policy test issue for display.
+type PolicyTestIssue struct {
+	ID                string `json:"id"`
+	Description       string `json:"description"`
+	Severity          string `json:"severity"`
+	PolicyID          string `json:"policy_id"`
+	State             string `json:"state"`
+	Source            string `json:"source"`
+	RemediationAdvice string `json:"remediation_advice"`
+}
+
+// TestResult is the parsed test result used for pretty and JSON output.
+type TestResult struct {
+	Issues  []PolicyTestIssue `json:"issues"`
+	Summary []byte            `json:"summary"`
+}
+
+// severityLevel returns the index in DEFAULT_SEVERITIES for ordering (higher = more severe).
+// Unknown severities return -1 so they sort last.
+func severityLevel(s string) int {
+	idx := slices.IndexFunc(json_schemas.DEFAULT_SEVERITIES, func(sev string) bool {
+		return strings.EqualFold(sev, s)
+	})
+	return idx
+}
+
+func buildTestSummary(issues []PolicyTestIssue) ([]byte, error) {
+	bySeverity := lo.GroupBy(issues, func(issue PolicyTestIssue) string {
+		return issue.Severity
+	})
+
+	summary := json_schemas.TestSummary{}
+	for severity, issues := range bySeverity {
+		openCount := lo.CountBy(issues, func(issue PolicyTestIssue) bool {
+			return issue.State == "open"
+		})
+		summary.Results = append(summary.Results, json_schemas.TestSummaryResult{
+			Severity: severity,
+			Total:    len(issues),
+			Open:     openCount,
+			Ignored:  len(issues) - openCount,
+		})
+	}
+	data, err := json.Marshal(summary)
+	if err != nil {
+		return nil, fmt.Errorf("marshal test summary: %w", err)
+	}
+	return data, nil
+}
+
+// ParseTestResult unmarshals the API JSON string into TestResult.
+func ParseTestResult(jsonStr string) (*TestResult, error) {
+	var raw rawTestResponse
+	if err := json.Unmarshal([]byte(jsonStr), &raw); err != nil {
+		return nil, fmt.Errorf("parse test result: %w", err)
+	}
+	issues := raw.Data.Attributes.Issues
+	slices.SortFunc(issues, func(a, b PolicyTestIssue) int {
+		sa, sb := severityLevel(a.Severity), severityLevel(b.Severity)
+		if sa != sb {
+			return sb - sa // higher severity first
+		}
+		if a.ID != b.ID {
+			return strings.Compare(a.ID, b.ID)
+		}
+		return strings.Compare(a.Description, b.Description)
+	})
+	// filter out closed issues
+	issues = lo.Filter(issues, func(issue PolicyTestIssue, _ int) bool {
+		return issue.State == "open" || issue.State == "ignored"
+	})
+	summaryPayload, err := buildTestSummary(issues)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build test summary: %w", err)
+	}
+
+	return &TestResult{
+		Issues:  issues,
+		Summary: summaryPayload,
+	}, nil
+}

--- a/internal/commands/aibomcreate/testresultparser_test.go
+++ b/internal/commands/aibomcreate/testresultparser_test.go
@@ -1,0 +1,151 @@
+package aibomcreate_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-ai-bom/internal/commands/aibomcreate"
+)
+
+func TestParseTestResult_SingleOpenIssue(t *testing.T) {
+	jsonStr := `{
+		"data":{
+			"id":"run-1",
+			"type":"test",
+			"attributes":{
+				"issues":[{
+					"id":"issue-1",
+					"description":"Missing license",
+					"severity":"high",
+					"policy_id":"pol-123",
+					"state":"open",
+					"source":"policy",
+					"remediation_advice":"Add a LICENSE file"
+				}]
+			}
+		}
+	}`
+	res, err := aibomcreate.ParseTestResult(jsonStr)
+	require.NoError(t, err)
+	require.Len(t, res.Issues, 1)
+	assert.Equal(t, "issue-1", res.Issues[0].ID)
+	assert.Equal(t, "Missing license", res.Issues[0].Description)
+	assert.Equal(t, "high", res.Issues[0].Severity)
+	assert.Equal(t, "pol-123", res.Issues[0].PolicyID)
+	assert.Equal(t, "open", res.Issues[0].State)
+	assert.Equal(t, "Add a LICENSE file", res.Issues[0].RemediationAdvice)
+
+	var summary struct {
+		Results []struct {
+			Severity string `json:"severity"`
+			Total    int    `json:"total"`
+			Open     int    `json:"open"`
+			Ignored  int    `json:"ignored"`
+		} `json:"results"`
+	}
+	err = json.Unmarshal(res.Summary, &summary)
+	require.NoError(t, err)
+	require.Len(t, summary.Results, 1)
+	assert.Equal(t, "high", summary.Results[0].Severity)
+	assert.Equal(t, 1, summary.Results[0].Total)
+	assert.Equal(t, 1, summary.Results[0].Open)
+	assert.Equal(t, 0, summary.Results[0].Ignored)
+}
+
+func TestParseTestResult_SortsBySeverity(t *testing.T) {
+	jsonStr := `{
+		"data":{
+			"id":"run-1",
+			"type":"test",
+			"attributes":{
+				"issues":[
+					{"id":"a","description":"Low","severity":"low","state":"open"},
+					{"id":"b","description":"Critical","severity":"critical","state":"open"},
+					{"id":"c","description":"Medium","severity":"medium","state":"open"},
+					{"id":"d","description":"High","severity":"high","state":"open"}
+				]
+			}
+		}
+	}`
+	res, err := aibomcreate.ParseTestResult(jsonStr)
+	require.NoError(t, err)
+	require.Len(t, res.Issues, 4)
+	assert.Equal(t, "critical", res.Issues[0].Severity)
+	assert.Equal(t, "high", res.Issues[1].Severity)
+	assert.Equal(t, "medium", res.Issues[2].Severity)
+	assert.Equal(t, "low", res.Issues[3].Severity)
+}
+
+func TestParseTestResult_FiltersOutClosedIssues(t *testing.T) {
+	jsonStr := `{
+		"data":{
+			"id":"run-1",
+			"type":"test",
+			"attributes":{
+				"issues":[
+					{"id":"open-1","description":"Open","severity":"high","state":"open"},
+					{"id":"ignored-1","description":"Ignored","severity":"medium","state":"ignored"},
+					{"id":"closed-1","description":"Closed","severity":"low","state":"closed"}
+				]
+			}
+		}
+	}`
+	res, err := aibomcreate.ParseTestResult(jsonStr)
+	require.NoError(t, err)
+	require.Len(t, res.Issues, 2)
+	ids := make([]string, len(res.Issues))
+	for i, iss := range res.Issues {
+		ids[i] = iss.ID
+	}
+	assert.ElementsMatch(t, []string{"open-1", "ignored-1"}, ids)
+}
+
+func TestParseTestResult_SummaryCountsOpenAndIgnored(t *testing.T) {
+	jsonStr := `{
+		"data":{
+			"id":"run-1",
+			"type":"test",
+			"attributes":{
+				"issues":[
+					{"id":"1","description":"A","severity":"high","state":"open"},
+					{"id":"2","description":"B","severity":"high","state":"ignored"},
+					{"id":"3","description":"C","severity":"medium","state":"open"}
+				]
+			}
+		}
+	}`
+	res, err := aibomcreate.ParseTestResult(jsonStr)
+	require.NoError(t, err)
+
+	var summary struct {
+		Results []struct {
+			Severity string `json:"severity"`
+			Total    int    `json:"total"`
+			Open     int    `json:"open"`
+			Ignored  int    `json:"ignored"`
+		} `json:"results"`
+	}
+	err = json.Unmarshal(res.Summary, &summary)
+	require.NoError(t, err)
+	bySev := make(map[string]struct{ Total, Open, Ignored int })
+	for _, r := range summary.Results {
+		bySev[r.Severity] = struct{ Total, Open, Ignored int }{r.Total, r.Open, r.Ignored}
+	}
+	assert.Equal(t, 2, bySev["high"].Total)
+	assert.Equal(t, 1, bySev["high"].Open)
+	assert.Equal(t, 1, bySev["high"].Ignored)
+	assert.Equal(t, 1, bySev["medium"].Total)
+	assert.Equal(t, 1, bySev["medium"].Open)
+	assert.Equal(t, 0, bySev["medium"].Ignored)
+}
+
+func TestParseTestResult_MissingData(t *testing.T) {
+	// Empty root object: attributes.issues is nil; after filter we get empty slice.
+	res, err := aibomcreate.ParseTestResult(`{}`)
+	require.NoError(t, err)
+	assert.Empty(t, res.Issues)
+	assert.NotNil(t, res.Summary)
+}


### PR DESCRIPTION
Change how we handle issues for the AI-BOM test.

### Properly handle issue states

After confirming with product, we are now only displaying **Open** and **Ignored** issues (closed issues are not displayed).
<img width="1045" height="482" alt="image" src="https://github.com/user-attachments/assets/4802b6df-ff6d-49a9-8ba0-50d4bfcbf346" />

For the json output case, we are still showing **all** issues.

### Exit code based on severity threshold

Appending a `content_type.TEST_SUMMARY` in the right format to the `workflow.Data` we send causes the upstream CLI to change the return code to 1 if there are any **open** issues that pass the severity threshold (consistent with the rest of snyk).

<img width="1264" height="108" alt="image" src="https://github.com/user-attachments/assets/36cbfdef-c4cf-41d1-b33b-016a58b085d6" />

In addition, changed the behavior to fail in case we fail to parse the test issues response object instead of returning the raw json in that case.

