### PR TITLE
chore: remove experimental flag

### DIFF
--- a/internal/commands/aibomcreate/aibomcreate.go
+++ b/internal/commands/aibomcreate/aibomcreate.go
@@ -37,6 +37,7 @@ var (
 
 func RegisterWorkflows(e workflow.Engine) error {
 	flagset := pflag.NewFlagSet("snyk-cli-extension-ai-bom", pflag.ExitOnError)
+	flagset.Bool(utils.FlagExperimental, false, "Deprecated: no longer required")
 	flagset.Bool(utils.FlagHTML, false, "Output the AI BOM in HTML format instead of JSON")
 	flagset.Bool(utils.FlagUpload, false, "Upload the AI BOM")
 	flagset.String(utils.FlagRepoName, "", "Repository name to use for the AI BOM")

--- a/internal/commands/aibomcreate/aibomcreate.go
+++ b/internal/commands/aibomcreate/aibomcreate.go
@@ -37,7 +37,6 @@ var (
 
 func RegisterWorkflows(e workflow.Engine) error {
 	flagset := pflag.NewFlagSet("snyk-cli-extension-ai-bom", pflag.ExitOnError)
-	flagset.Bool(utils.FlagExperimental, false, "This is an experiment feature that will contain breaking changes in future revisions")
 	flagset.Bool(utils.FlagHTML, false, "Output the AI BOM in HTML format instead of JSON")
 	flagset.Bool(utils.FlagUpload, false, "Upload the AI BOM")
 	flagset.String(utils.FlagRepoName, "", "Repository name to use for the AI BOM")
@@ -147,17 +146,10 @@ func RunAiBomWorkflow(
 	config := invocationCtx.GetConfiguration()
 
 	config.Set(configuration.RAW_CMD_ARGS, os.Args[1:])
-	experimental := config.GetBool(utils.FlagExperimental)
 	path := config.GetString(configuration.INPUT_DIRECTORY)
 	upload := config.GetBool(utils.FlagUpload)
 	repoName := config.GetString(utils.FlagRepoName)
 	jsonOutput := config.GetString(utils.FlagJSONFileOutput) != ""
-
-	// As this is an experimental feature, we only want to continue if the experimental flag is set
-	if !experimental {
-		logger.Debug().Msg("Required experimental flag is not present")
-		return nil, errors.NewCommandIsExperimentalError().SnykError
-	}
 
 	ctx := context.Background()
 	logger.Debug().Msgf("running command with orgId: %s", orgID)

--- a/internal/commands/aibomcreate/aibomcreate_test.go
+++ b/internal/commands/aibomcreate/aibomcreate_test.go
@@ -37,7 +37,6 @@ var exampleAIBOM = `{
 func TestAiBomWorkflow_HAPPY(t *testing.T) {
 	ictx := frameworkmock.NewMockInvocationContext(t)
 	ctrl := gomock.NewController(t)
-	ictx.GetConfiguration().Set(utils.FlagExperimental, true)
 	aiBomClient := aibomclientmock.NewMockAiBomClient(ctrl)
 	uploadRevisionID := uuid.New()
 	fileUploadClient := fileuploadmock.NewMockClient(ctrl)
@@ -63,7 +62,6 @@ func TestAiBomWorkflow_Upload_HAPPY(t *testing.T) {
 	ictx := frameworkmock.NewMockInvocationContext(t)
 	ctrl := gomock.NewController(t)
 	cfg := ictx.GetConfiguration()
-	cfg.Set(utils.FlagExperimental, true)
 	cfg.Set(utils.FlagUpload, true)
 	cfg.Set(utils.FlagRepoName, "repo-name")
 	aiBomClient := aibomclientmock.NewMockAiBomClient(ctrl)
@@ -94,7 +92,6 @@ func TestAiBomWorkflow_Upload_HAPPY(t *testing.T) {
 func TestAiBomWorkflow_HTML(t *testing.T) {
 	ictx := frameworkmock.NewMockInvocationContext(t)
 	ctrl := gomock.NewController(t)
-	ictx.GetConfiguration().Set(utils.FlagExperimental, true)
 	ictx.GetConfiguration().Set(utils.FlagHTML, true)
 	aiBomClient := aibomclientmock.NewMockAiBomClient(ctrl)
 	uploadRevisionID := uuid.New()
@@ -121,7 +118,6 @@ func TestAiBomWorkflow_HTML(t *testing.T) {
 func TestAiBomWorkflow_APIUnavailable(t *testing.T) {
 	ictx := frameworkmock.NewMockInvocationContext(t)
 	ctrl := gomock.NewController(t)
-	ictx.GetConfiguration().Set(utils.FlagExperimental, true)
 	aiBomClient := aibomclientmock.NewMockAiBomClient(ctrl)
 	unavailableError := errors.NewInternalError("unavailable")
 	fileUploadClient := fileuploadmock.NewMockClient(ctrl)
@@ -134,7 +130,6 @@ func TestAiBomWorkflow_APIUnavailable(t *testing.T) {
 
 func TestAiBomWorkflow_UPLOAD_BUNDLE_FAIL(t *testing.T) {
 	ictx := frameworkmock.NewMockInvocationContext(t)
-	ictx.GetConfiguration().Set(utils.FlagExperimental, true)
 	ctrl := gomock.NewController(t)
 	aiBomClient := aibomclientmock.NewMockAiBomClient(ctrl)
 	uploadRevisionID := uuid.New()
@@ -153,7 +148,6 @@ func TestAiBomWorkflow_UPLOAD_BUNDLE_FAIL(t *testing.T) {
 
 func TestAiBomWorkflow_NO_SUPPORTED_FILES(t *testing.T) {
 	ictx := frameworkmock.NewMockInvocationContext(t)
-	ictx.GetConfiguration().Set(utils.FlagExperimental, true)
 	ctrl := gomock.NewController(t)
 	aiBomClient := aibomclientmock.NewMockAiBomClient(ctrl)
 	uploadRevisionID := uuid.New()
@@ -171,7 +165,6 @@ func TestAiBomWorkflow_NO_SUPPORTED_FILES(t *testing.T) {
 
 func TestAiBomWorkflow_AIBOM_GENERATION_FAIL(t *testing.T) {
 	ictx := frameworkmock.NewMockInvocationContext(t)
-	ictx.GetConfiguration().Set(utils.FlagExperimental, true)
 	ctrl := gomock.NewController(t)
 	aiBomClient := aibomclientmock.NewMockAiBomClient(ctrl)
 	aiBomErr := errors.NewInternalError("Test error")
@@ -190,23 +183,11 @@ func TestAiBomWorkflow_AIBOM_GENERATION_FAIL(t *testing.T) {
 	assert.Equal(t, aiBomErr.SnykError, err)
 }
 
-func TestAiBomWorkflow_NO_EXPERIMENTAL(t *testing.T) {
-	ictx := frameworkmock.NewMockInvocationContext(t)
-	ctrl := gomock.NewController(t)
-	aiBomClient := aibomclientmock.NewMockAiBomClient(ctrl)
-	fileUploadClient := fileuploadmock.NewMockClient(ctrl)
-
-	_, err := aibomcreate.RunAiBomWorkflow(ictx, frameworkmock.MockOrgID, aiBomClient, fileUploadClient, false)
-	assert.EqualError(t, err, "Command is experimental")
-}
-
 func TestAiBomWorkflow_UNAUTHORIZED(t *testing.T) {
 	ictx := frameworkmock.NewMockInvocationContext(t)
 	ctrl := gomock.NewController(t)
 	aiBomClient := aibomclientmock.NewMockAiBomClient(ctrl)
 	fileUploadClient := fileuploadmock.NewMockClient(ctrl)
-
-	ictx.GetConfiguration().Set(utils.FlagExperimental, true)
 
 	// Unauthorized either won't have an orgId
 	ictx.GetConfiguration().Set(configuration.ORGANIZATION, "")

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -28,10 +28,6 @@ func NewNoSupportedFilesError() *AiBomError {
 	return &AiBomError{SnykError: aibom_errors.NewNoSupportedFilesError("")}
 }
 
-func NewCommandIsExperimentalError() *AiBomError {
-	return &AiBomError{SnykError: cli_errors.NewCommandIsExperimentalError("Snyk aibom is experimental and likely to change.")}
-}
-
 func NewInvalidArgumentError(msg string) *AiBomError {
 	return &AiBomError{SnykError: cli_errors.NewCommandArgsError(msg)}
 }


### PR DESCRIPTION
Remove `--experimental` flag requirement from the `aibom` and `aibom test` commands.
